### PR TITLE
V1

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -65,6 +65,10 @@ func main() {
 	for {
 		select {
 		case <-quit:
+			msg := "leaveTheRoom"
+			if err := leaveTheRoom(host, msg); err != nil {
+				log.Fatal(err)
+			}
 			goto end
 		case m := <-chMsg:
 			printMessage(m)
@@ -74,6 +78,7 @@ func main() {
 	}
 end:
 
+	consumer.Close(chErr)
 	fmt.Println("\nyou have abandoned the room")
 
 }
@@ -99,6 +104,12 @@ func joinTheRoom(host string) error {
 func publishMessage(host, message string) error {
 	d := Data{Username: user, Message: message}
 	endpoint := fmt.Sprintf("%s/publish", host)
+	return do(endpoint, d)
+}
+
+func leaveTheRoom(host, message string) error {
+	d := Data{Username: user, Message: message}
+	endpoint := fmt.Sprintf("%s/leaveTheRoom", host)
 	return do(endpoint, d)
 }
 

--- a/pkg/consumer.go
+++ b/pkg/consumer.go
@@ -8,4 +8,5 @@ import (
 type Consumer interface {
 	// Read read into the stream
 	Read(ctx context.Context, chMsg chan Message, chErr chan error)
+	Close(chErr chan error)
 }

--- a/pkg/kafka/consumer.go
+++ b/pkg/kafka/consumer.go
@@ -52,3 +52,10 @@ func (c *consumer) Read(ctx context.Context, chMsg chan kafkaexample.Message, ch
 		chMsg <- message
 	}
 }
+
+func (c *consumer) Close(chErr chan error) {
+	errClose := c.reader.Close()
+	if errClose != nil {
+		chErr <- errClose
+	}
+}


### PR DESCRIPTION
Nuevo endpoint en el servidor donde se publicó un mensaje para informar que el usuario en cuestión ha abandonado el chat

Uso del contexto, para cerrar el reader del consumer antes de acabar la ejecución.